### PR TITLE
Implement role-specific command descriptions for /role and /mycommands

### DIFF
--- a/src/commands/role.js
+++ b/src/commands/role.js
@@ -1,6 +1,7 @@
 // commands/role.js
 import { SlashCommandBuilder } from "discord.js";
 import { playerRoles } from "../helpers/gameState.js";
+import { ROLE_COMMANDS } from "./roleCommands.js"
 
 export default {
   data: new SlashCommandBuilder()
@@ -17,10 +18,14 @@ export default {
       });
     }
 
+    const commands = ROLE_COMMANDS[role] || "Good luck!";
+
     await interaction.reply({
       content:
         `🎭 **Your Role: ${role}**\n\n` +
+        `${commands}\n\n` +
         "Do not reveal your role to other players.\n" +
+        "Use `/mycommands` to view your role's commands at any time.\n" +
         "Good luck… 😈",
       ephemeral: true,
     });

--- a/src/commands/roleCommands.js
+++ b/src/commands/roleCommands.js
@@ -1,0 +1,27 @@
+import { SlashCommandBuilder } from "discord.js";
+import { playerRoles } from "../helpers/gameState.js";
+
+export const ROLE_COMMANDS = {
+  "Mafia": "🕵️ **Mafia Commands:**\n• `/kill` - Eliminate a player in this round.",
+  "Doctor": "🩺 **Doctor Commands:**\n• `/save` - Choose a player to protect.",
+  "Civilian": "👥 **Civilian Commands:**\n• '/vote [username]' - Vote for who you think is the Mafia."
+};
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("mycommands")
+    .setDescription("List commands for your role"),
+
+  async execute(interaction) {
+    const role = playerRoles.get(interaction.user.id);
+
+    if (!role) {
+      return interaction.reply({ content: "No role found!", ephemeral: true });
+    }
+
+    await interaction.reply({
+      content: `${ROLE_COMMANDS[role]}`,
+      ephemeral: true,
+    });
+  },
+};


### PR DESCRIPTION
Created roleCommands.js which includes `/mycommands` for players to view the commands associated with their role.
Updated role.js to display the user's commands when using `/role`.

Closes #16 